### PR TITLE
v2.11.1: fix Windows file lock on template PDF after Load Data

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,7 +26,7 @@ All modules are pure Python with no circular imports. The main module imports al
 
 ### `pdf_generator.py` -- Main Application
 
-**~3230 lines.** Contains the `BulkPDFGenerator` class plus supporting dialog classes.
+**~3650 lines.** Contains the `BulkPDFGenerator` class plus supporting dialog classes.
 
 **Responsibilities:**
 - tkinter root window, notebook (tabs), and all widget layout
@@ -108,14 +108,14 @@ Renders PDF pages as PIL Images and draws field highlight overlays.
 **Two-tier caching:**
 
 1. **Memory cache** -- `OrderedDict` with LRU eviction, capped at 5 entries (~60MB at 200 DPI). Most-recently-used pages stay in memory for instant re-rendering.
-2. **Disk cache** -- PNG files in `.preview_cache/` directory. Survives app restarts. Page images are named `page_{N}_dpi_{D}.png`.
+2. **Disk cache** -- PNG files in `.preview_cache/` directory. Survives app restarts. Page images are named `{pdf_hash}_page_{N}_dpi_{D}.png`. The `{pdf_hash}` prefix (an 8-char MD5 of the PDF path) prevents stale cross-PDF cache hits when two templates happen to share a page number/DPI combination.
 
 **Cache flow:**
 ```
 Request page 3 at 150 DPI
   → Check memory cache (OrderedDict key "3_150")
     → HIT: return cached Image (move to end for LRU)
-    → MISS: check disk cache (page_3_dpi_150.png)
+    → MISS: check disk cache ({pdf_hash}_page_3_dpi_150.png)
       → HIT: load from disk, img.load() to release file handle, store in memory
       → MISS: render via fitz, save to disk, store in memory
 ```
@@ -124,7 +124,41 @@ Request page 3 at 150 DPI
 
 **Font path reliability:** Platform font loading uses absolute paths (`%WINDIR%\Fonts\segoeui.ttf` on Windows, `/System/Library/Fonts/Helvetica.ttc` on macOS) with fallback to `ImageFont.load_default()` if the system font is unavailable.
 
-**Cache cleanup:** `clear_cache()` only deletes files matching `page_*.png` to avoid accidentally removing unrelated files. Each deletion is wrapped in `try/except OSError` to handle locked files gracefully.
+**Cache cleanup:** `clear_cache()` only deletes files containing `_page_` in the name with a `.png` extension, so any user files in the cache directory are left alone. Each deletion is wrapped in `try/except OSError` to handle locked files gracefully.
+
+**Disk cache size cap (v2.11):** `_prune_disk_cache()` enforces a 200 MB ceiling. It runs on `__enter__` (when a `VisualPreviewGenerator` opens a PDF) and evicts oldest entries first by mtime until the cumulative size is back under the cap. Non-cache files in the directory are ignored. Without this cap the cache could grow unbounded for users who analysed many large PDFs.
+
+---
+
+### `preview_renderer.py` -- Threaded Preview Renderer
+
+Wraps `VisualPreviewGenerator` with debouncing, a stale-result guard, and background PIL work, so the UI stays responsive when a teacher clicks rapidly through fields.
+
+**Thread boundary (CRITICAL — v2.11):** `fitz.Document` is **not** thread-safe and must only be touched on the main thread. `PreviewRenderer` enforces this by:
+1. Calling `_get_page_image()` (which uses `fitz`) only from the main-thread debounce callback `_on_debounce_fire()`.
+2. Capturing canvas dimensions via `_capture_canvas_dims()` on the main thread *before* spawning the resize worker — Tcl (`canvas.winfo_*`) is also not thread-safe, so passing the captured ints into the worker is the only safe pattern.
+3. Restricting worker threads to pure PIL operations (`Image.copy()`, `ImageDraw`, `Image.resize()`).
+
+**Render pipeline:**
+```
+request_preview(field, zoom)
+  → debounce timer (150ms)              [main thread]
+  → _on_debounce_fire                   [main thread — fitz access OK]
+    → _get_page_image (PyMuPDF)
+    → spawn _worker_render thread
+  → _worker_render                      [worker — PIL only]
+    → copy + draw overlays
+    → root.after(0, _do_resize)
+  → _do_resize                          [main thread — capture canvas dims]
+    → spawn _resize_and_deliver thread
+  → _resize_and_deliver                 [worker — PIL.resize only]
+    → root.after(0, _deliver)
+  → _deliver                            [main thread — Tk PhotoImage, canvas update]
+```
+
+**Stale-result guard:** every request increments `_request_id`. Worker threads check `my_id != self._request_id` at every hand-off and bail out silently if a newer request has superseded them. This prevents an old, slow render from overwriting a fresh one.
+
+**Two-pass quality:** the first render uses `Image.Resampling.BILINEAR` (fast). 300 ms after the fast pass, a chained `_do_resize(use_lanczos=True)` re-renders with `Image.Resampling.LANCZOS` for crisp final output. Only the fast pass schedules the quality pass, so chaining cannot recurse.
 
 ---
 
@@ -285,7 +319,7 @@ Two tiers to balance speed and memory:
 | Tier | Storage | Capacity | Eviction | Persistence |
 |------|---------|----------|----------|-------------|
 | Memory | `OrderedDict` | 5 entries (~60MB) | LRU (oldest evicted) | Session only |
-| Disk | PNG files in `.preview_cache/` | Unlimited | Manual (clear_cache) | Across sessions |
+| Disk | PNG files in `.preview_cache/` | 200 MB | Auto-prune oldest by mtime on `__enter__`; manual via `clear_cache` | Across sessions |
 
 **Why two tiers?** Rendering a PDF page at 200 DPI via PyMuPDF takes 500-800ms. The memory cache makes repeated clicks on the same page instant (~50ms). The disk cache means previously rendered pages load quickly even after app restart.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ A Python desktop app (tkinter/ttkbootstrap GUI) that batch-fills PDF forms from 
 
 | File | Purpose |
 |------|---------|
-| `pdf_generator.py` | Main application (~3230 lines) — GUI, dialogs, generation pipeline |
+| `pdf_generator.py` | Main application (~3650 lines) — GUI, dialogs, generation pipeline |
 | `models.py` | Data models: `PDFField`, `TemplateConfig`, `AppSettings` |
 | `pdf_analyzer.py` | PDF field extraction engine (PyMuPDF) |
 | `visual_preview.py` | PDF page rendering + field highlighting, dual-tier cache |
@@ -120,7 +120,7 @@ Excel serial date range validation: only serials 1–2958465 are converted (1900
 
 - **Python**: Use `venv/bin/python` — system `python`/`python3` doesn't have project deps. Install pytest once: `venv/bin/pip install pytest`.
 - **Run tests**: `venv/bin/python -m pytest tests/ -v`
-- **Performance tests**: `tests/test_performance.py` uses `inspect.getsource()` to verify structural patterns (anti-patterns absent from source) rather than flaky timing assertions. 17 tests covering threading, debounce, batch updates, throttling, dialog geometry.
+- **Performance tests**: `tests/test_performance.py` uses `inspect.getsource()` to verify structural patterns (anti-patterns absent from source) rather than flaky timing assertions. 21 tests covering threading, debounce, batch updates, throttling, dialog geometry.
 - **Main class**: `BulkPDFGenerator` (not `BulkPDFApp` or similar)
 - **About tab method**: `setup_tab_about()` (not `setup_tab4_about`)
 - **Generation worker method**: `run_generation_tab3()` (not `generate_pdfs_worker` or similar)

--- a/README.md
+++ b/README.md
@@ -818,6 +818,15 @@ bulk-pdf-extractor-and-generator/
 
 ## Release Notes
 
+### v2.11.1 — May 2026
+
+**Small reliability fix.** Patch release — no new features, no changes to how you use the app. Safe to upgrade at any time.
+
+- **Fixed: template PDF stayed "in use" by the app on Windows after Load Data** — On the **Generate PDFs** tab, after clicking **Load Data**, Windows could keep treating your template PDF as "open by another program". You may have noticed this if you tried to open the same template in Adobe Acrobat (got a "file in use" warning), rename or move the template in File Explorer (blocked), run a second copy of the app on the same template, or email/upload the template while the app was still open. The file is now released back to Windows as soon as the app finishes reading the form fields. macOS users were not affected.
+- **Behind the scenes** — internal architecture documentation has been brought up to date with the threading and caching improvements that landed in v2.11. No user-facing change.
+
+---
+
 ### v2.11 — April 2026
 
 **Reliability, performance, and stability fixes** — full codebase audit pass.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+**Small reliability fix.** This is a patch release with one targeted fix — no new features and no changes to how you use the app. Safe to upgrade at any time.
+
+- **Fixed: template PDF stayed "in use" by the app on Windows after Load Data** — On the **Generate PDFs** tab, after you clicked **Load Data**, Windows could keep treating your template PDF as "open by another program" — even though you were just using it as a source for field names. You may have noticed this if you tried to:
+  - Open the same template in Adobe Acrobat or Adobe Reader and got a "file in use" warning,
+  - Rename, move, or delete the template in File Explorer and got blocked by Windows,
+  - Run a second copy of the app on the same template,
+  - Email or upload the template while the app was still open.
+
+  The file is now released back to Windows as soon as the app finishes reading the form fields, so all of the above just work normally. **macOS users were not affected** — macOS handles open file handles differently and never blocked these operations.
+
+- **Behind the scenes** — the app's internal architecture documentation has been brought up to date with the threading and caching improvements that landed in v2.11. No user-facing change.
+
+---
+
 <!-- Release notes for the next tagged release.
      The GitHub Actions workflow reads this file and injects it into the
      release page. Write in plain English for teachers — no jargon.

--- a/pdf_generator.py
+++ b/pdf_generator.py
@@ -2959,13 +2959,20 @@ class BulkPDFGenerator:
             return
 
         try:
-            # Load PDF and get field names
+            # Load PDF and get field names. Close the reader as soon as the
+            # field-name strings are hoisted out — pypdf 6.x keys are plain
+            # str but values are pypdf.generic objects that need the open
+            # file handle, so never store fields.values() past the close.
+            # Without this finally block the template PDF stays locked on
+            # Windows until the app exits or GC runs.
             reader = PdfReader(pdf_path)
-            self.pdf_fields = []  # Always reset before re-reading
-            fields = reader.get_fields()
-            if fields:
-                self.pdf_fields = list(fields.keys())
-            else:
+            try:
+                fields = reader.get_fields()
+                self.pdf_fields = list(fields.keys()) if fields else []
+            finally:
+                reader.close()
+
+            if not self.pdf_fields:
                 messagebox.showerror("Error", "The PDF template has no fillable form fields.")
                 return
 

--- a/tests/test_data_fidelity.py
+++ b/tests/test_data_fidelity.py
@@ -54,6 +54,47 @@ class TestCsvLeadingZeroPreservation(unittest.TestCase):
         self.assertEqual(df_str.iloc[1]['Student ID'], '00045')
 
 
+class TestPdfReaderClosedInLoadData(unittest.TestCase):
+    """load_data_tab3 must close the PdfReader so Windows releases the file lock.
+
+    Without this, the template PDF stays "in use" until the app exits, blocking
+    teachers from opening the same template in Adobe or renaming/moving the file.
+    Mirrors the v2.11 fix in run_generation_tab3 (C3 / 8d09e81).
+    """
+
+    def test_load_data_closes_reader_in_finally(self):
+        """The PdfReader opened in load_data_tab3 must be closed in a finally block."""
+        from pdf_generator import BulkPDFGenerator
+        import inspect
+        source = inspect.getsource(BulkPDFGenerator.load_data_tab3)
+
+        self.assertIn('PdfReader(', source,
+                      "load_data_tab3 should still open a PdfReader")
+        self.assertIn('reader.close()', source,
+                      "load_data_tab3 must explicitly close the PdfReader to "
+                      "release the Windows file lock — without this the "
+                      "template PDF stays in use until the app exits")
+
+        # Walk lines: after `reader = PdfReader(`, the next `try:` must be
+        # followed by a `finally:` that contains `reader.close()`. This guards
+        # against a future refactor that drops the close into the happy path.
+        lines = source.split('\n')
+        opened_at = next(
+            (i for i, ln in enumerate(lines) if 'PdfReader(' in ln and 'reader' in ln),
+            None,
+        )
+        self.assertIsNotNone(opened_at, "expected a `reader = PdfReader(...)` line")
+
+        tail = '\n'.join(lines[opened_at:])
+        try_idx = tail.find('try:')
+        finally_idx = tail.find('finally:')
+        close_idx = tail.find('reader.close()')
+        self.assertTrue(0 <= try_idx < finally_idx < close_idx,
+                        "PdfReader must be opened, then `try:` then `finally: "
+                        "reader.close()` — current order does not guarantee "
+                        "close on the early-return path")
+
+
 class TestFallbackPathDateConversion(unittest.TestCase):
     """Fallback auto-match path must pass data_type so date fields convert (C2)."""
 


### PR DESCRIPTION
## Summary

Patch release addressing a single user-visible Windows bug found during the v2.11 audit:

- **`load_data_tab3` opened a `PdfReader` and never closed it.** On Windows the file handle was held until the app exited, leaving the template PDF "in use" — blocking the user from opening it in Adobe, renaming/moving it in Explorer, or running a second app instance on the same template. macOS users were not affected.

The fix mirrors the v2.11 pattern from `run_generation_tab3`: wrap the reader in `try/finally`, hoist the field-name strings out, then `reader.close()`. A structural test in `tests/test_data_fidelity.py` asserts the `try → finally → reader.close()` order so a future refactor can't silently regress.

## Changes

- `pdf_generator.py:2961-3022` — `load_data_tab3` now closes the `PdfReader` in a `finally` block (1 file, 11 lines net change).
- `tests/test_data_fidelity.py` — new `TestPdfReaderClosedInLoadData` class (1 new test, 50/50 suite passes).
- `ARCHITECTURE.md` — line count refresh, disk-cache filename pattern updated, new 200 MB cap paragraph, new top-level `preview_renderer.py` section documenting the v2.11 thread boundary.
- `CLAUDE.md` — line count refresh, performance test count 17 → 21.
- `RELEASE_NOTES.md` + `README.md` — teacher-friendly v2.11.1 release notes.

## Senior-engineer review

The plan was reviewed by the architect agent before implementation. Their amendments were folded in:

1. Reasoning for why `list(fields.keys())` is safe after `reader.close()` is now in a code comment.
2. New test placed in `test_data_fidelity.py` (not `test_generation_perf.py`) because it's a data-load correctness concern.
3. Additional doc drift caught: `ARCHITECTURE.md:29` line count, `:127` cache-cleanup pattern, `:288` "Unlimited" disk-cache row.
4. Tag strategy made explicit: ship as `v2.11.1` to push the fix to teachers via GitHub Actions auto-build.

## Test plan

- [x] `venv/bin/python -m pytest tests/ -v` → 50/50 passed
- [ ] After merge: tag `v2.11.1` and push tag → GitHub Actions builds Windows .exe + macOS .dmg → release auto-published
- [ ] Manual smoke test on Windows: install v2.11.1, click Load Data on Tab 3 with a template, then open the same template in Acrobat — should not warn "file in use"

🤖 Generated with [Claude Code](https://claude.com/claude-code)