### PR TITLE
ci: clear release notes after v2.11.1 publish

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,26 +1,13 @@
-**Small reliability fix.** This is a patch release with one targeted fix — no new features and no changes to how you use the app. Safe to upgrade at any time.
-
-- **Fixed: template PDF stayed "in use" by the app on Windows after Load Data** — On the **Generate PDFs** tab, after you clicked **Load Data**, Windows could keep treating your template PDF as "open by another program" — even though you were just using it as a source for field names. You may have noticed this if you tried to:
-  - Open the same template in Adobe Acrobat or Adobe Reader and got a "file in use" warning,
-  - Rename, move, or delete the template in File Explorer and got blocked by Windows,
-  - Run a second copy of the app on the same template,
-  - Email or upload the template while the app was still open.
-
-  The file is now released back to Windows as soon as the app finishes reading the form fields, so all of the above just work normally. **macOS users were not affected** — macOS handles open file handles differently and never blocked these operations.
-
-- **Behind the scenes** — the app's internal architecture documentation has been brought up to date with the threading and caching improvements that landed in v2.11. No user-facing change.
-
----
-
 <!-- Release notes for the next tagged release.
      The GitHub Actions workflow reads this file and injects it into the
      release page. Write in plain English for teachers — no jargon.
+
+     If this file is empty (just this comment), release notes are
+     auto-generated from conventional commit messages. You only need
+     to write here if you want custom wording for a release.
 
      Format: Markdown bullet list. Bold the headline, em-dash, then explain.
      Example:
        - **New feature name** — What it does and why teachers care.
        - **Fixed: bug description** — What was broken and how it's fixed.
-
-     After a release is published, clear everything above the instructions
-     comment and start fresh for the next version.
 -->


### PR DESCRIPTION
Post-release housekeeping. The release workflow tried to open this PR automatically but was blocked by repo settings (Actions does not have permission to create pull requests). Doing it manually so the next release doesn't carry over the v2.11.1 wording.

The workflow itself ran fine and the v2.11.1 release was published successfully — see [the release page](https://github.com/mrdavearms/bulk-pdf-extractor-and-generator/releases/tag/v2.11.1).

To make this fully automatic next time, enable **Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)